### PR TITLE
Enhance user experience when building snap (snapcraft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Snapcraft build artefacts
+parts/
+prime/
+stage/
+*.snap
+
+# Also ignore node modules installed
+node_modules/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,3 +16,4 @@ parts:
         plugin: nodejs
         source: https://github.com/01org/iot-rest-api-server.git
         source-branch: master
+        build-packages: [git, scons, libtool, autoconf, valgrind, doxygen, wget, unzip, libboost-dev, libboost-program-options-dev, libboost-thread-dev, uuid-dev, libexpat1-dev, libglib2.0-dev]


### PR DESCRIPTION
- Add .gitignore to ignore snapcrat build artefacts
- Add build dependencies to snapcraft.yaml so they are
  automatically installed if not yet available on the build system

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>